### PR TITLE
Adding support for tracking broken external Uris

### DIFF
--- a/src/LinkValidator.Tests/End2EndSpecs.ShouldCrawlWebsiteCorrectly.verified.txt
+++ b/src/LinkValidator.Tests/End2EndSpecs.ShouldCrawlWebsiteCorrectly.verified.txt
@@ -1,5 +1,7 @@
 ﻿# Sitemap for `http://localhost:8080/`
 
+## Internal Pages
+
 | URL                   | StatusCode | Linked From                                             |
 | --------------------- | ---------- | ------------------------------------------------------- |
 | `/`                   | OK         | \-                                                      |
@@ -14,7 +16,13 @@
 ### `/` has broken links:
 
 - `/page2.html` (NotFound)
+- `http://getakka.net/broken-link` (NotFound)
+
+### `/about/index.html` has broken links:
+
+- `http://getakka.net/broken-link` (NotFound)
 
 ### `/index.html` has broken links:
 
 - `/page2.html` (NotFound)
+- `http://getakka.net/broken-link` (NotFound)

--- a/src/LinkValidator.Tests/End2EndSpecs.cs
+++ b/src/LinkValidator.Tests/End2EndSpecs.cs
@@ -44,7 +44,7 @@ public class End2EndSpecs : TestKit, IClassFixture<TestWebServerFixture>
         
         // act
         var crawlResult = await CrawlWebsite(Sys, baseUrl);
-        var markdown = GenerateMarkdown(baseUrl, crawlResult);
+        var markdown = GenerateMarkdown(crawlResult);
         
         _output.WriteLine("=== RAW MARKDOWN OUTPUT ===");
         _output.WriteLine(markdown);

--- a/src/LinkValidator.Tests/ManualMarkdownTest.cs
+++ b/src/LinkValidator.Tests/ManualMarkdownTest.cs
@@ -2,11 +2,19 @@ using System.Collections.Immutable;
 using System.Net;
 using LinkValidator.Actors;
 using LinkValidator.Util;
+using Xunit.Abstractions;
 
 namespace LinkValidator.Tests;
 
 public class ManualMarkdownTest
 {
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public ManualMarkdownTest(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
     [Fact]
     public void TestRawMarkdownOutput()
     {
@@ -20,12 +28,14 @@ public class ManualMarkdownTest
                 ImmutableList<AbsoluteUri>.Empty
                     .Add(baseUri)
                     .Add(new AbsoluteUri(new Uri("http://localhost:8080/index.html")))));
-
-        var markdown = MarkdownHelper.GenerateMarkdown(baseUri, results);
         
-        Console.WriteLine("RAW MARKDOWN:");
-        Console.WriteLine(markdown);
-        Console.WriteLine("END RAW MARKDOWN");
+        var crawlResults = new CrawlReport(baseUri, results, ImmutableSortedDictionary<string, CrawlRecord>.Empty);
+
+        var markdown = MarkdownHelper.GenerateMarkdown(crawlResults);
+        
+        _testOutputHelper.WriteLine("RAW MARKDOWN:");
+        _testOutputHelper.WriteLine(markdown);
+        _testOutputHelper.WriteLine("END RAW MARKDOWN");
         
         // Check for escaping
         Assert.DoesNotContain("\\/", markdown);

--- a/src/LinkValidator.Tests/ParseHelperSpecs.cs
+++ b/src/LinkValidator.Tests/ParseHelperSpecs.cs
@@ -38,9 +38,9 @@ public class ParseHelperSpecs
 
         // Assert
         uris.Should().HaveCount(3);
-        uris.Should().Contain(new AbsoluteUri(new Uri("http://example.com/about")));
-        uris.Should().Contain(new AbsoluteUri(new Uri("http://example.com/contact")));
-        uris.Should().Contain(new AbsoluteUri(new Uri("http://example.com/faq")));
+        uris.Should().Contain((new AbsoluteUri(new Uri("http://example.com/about")), LinkType.Internal));
+        uris.Should().Contain((new AbsoluteUri(new Uri("http://example.com/contact")), LinkType.Internal));
+        uris.Should().Contain((new AbsoluteUri(new Uri("http://example.com/faq")), LinkType.Internal));
     }
 
     // create a string that contains HTML linking to a few different URLs using absolute links
@@ -71,9 +71,9 @@ public class ParseHelperSpecs
         uris.Should().HaveCount(3);
 
         // notice that we convert the scheme to https
-        uris.Should().Contain(new AbsoluteUri(new Uri("https://example.com/about")));
-        uris.Should().Contain(new AbsoluteUri(new Uri("https://example.com/contact")));
-        uris.Should().Contain(new AbsoluteUri(new Uri("https://example.com/faq")));
+        uris.Should().Contain((new AbsoluteUri(new Uri("https://example.com/about")), LinkType.Internal));
+        uris.Should().Contain((new AbsoluteUri(new Uri("https://example.com/contact")), LinkType.Internal));
+        uris.Should().Contain((new AbsoluteUri(new Uri("https://example.com/faq")), LinkType.Internal));
     }
 
     private const string MixedHtml = """
@@ -100,9 +100,10 @@ public class ParseHelperSpecs
         var uris = ParseHelpers.ParseLinks(MixedHtml, uri);
 
         // Assert
-        uris.Should().HaveCount(2); // don't count the FAKEURL one
-        uris.Should().Contain(new AbsoluteUri(new Uri("http://example.com/about")));
-        uris.Should().Contain(new AbsoluteUri(new Uri("http://example.com/contact")));
+        uris.Where(c => c.type == LinkType.Internal).Should().HaveCount(2); // don't count the FAKEURL one
+        uris.Where(c => c.type == LinkType.External).Should().HaveCount(1); // do count the FAKEURL one
+        uris.Should().Contain((new AbsoluteUri(new Uri("http://example.com/about")), LinkType.Internal));
+        uris.Should().Contain((new AbsoluteUri(new Uri("http://example.com/contact")), LinkType.Internal));
     }
 
     public const string TweetShareLink = """
@@ -794,7 +795,8 @@ public class ParseHelperSpecs
         var uris = ParseHelpers.ParseLinks(TweetShareLink, uri);
 
         // Assert
-        uris.Should().HaveCount(22);
+        uris.Where(c => c.type == LinkType.Internal).Should().HaveCount(22);
+        uris.Where(c => c.type == LinkType.External).Should().HaveCount(15);
     }
 
     private const string LinkFragmentsHtml = """
@@ -822,7 +824,7 @@ public class ParseHelperSpecs
 
         // Assert
         uris.Should().HaveCount(2);
-        uris.Should().Contain(new AbsoluteUri(new Uri("http://example.com/about")));
-        uris.Should().Contain(new AbsoluteUri(new Uri("http://example.com/contact")));
+        uris.Should().Contain((new AbsoluteUri(new Uri("http://example.com/about")), LinkType.Internal));
+        uris.Should().Contain((new AbsoluteUri(new Uri("http://example.com/contact")), LinkType.Internal));
     }
 }

--- a/src/LinkValidator.Tests/pages/about/index.html
+++ b/src/LinkValidator.Tests/pages/about/index.html
@@ -13,5 +13,12 @@
     <li><a href="/about/contact.html">Contact</a></li>
 </ul>
 
+<b>Other:</b>
+<ul>
+    <li><a href="https://phobos.petabridge.com/">Phobos</a></li>
+    <li><a href="https://getakka.net/">Akka.NET Documentation</a></li>
+    <li><a href="https://getakka.net/broken-link">Akka.NET Documentation (Broken Link)</a></li>
+</ul>
+
 </body>
 </html>

--- a/src/LinkValidator.Tests/pages/index.html
+++ b/src/LinkValidator.Tests/pages/index.html
@@ -19,5 +19,12 @@
     <li><a href="/about/contact.html">Contact</a></li>
 </ul>
 
+<b>Other:</b>
+<ul>
+    <li><a href="https://phobos.petabridge.com/">Phobos</a></li>
+    <li><a href="https://getakka.net/">Akka.NET Documentation</a></li>
+    <li><a href="https://getakka.net/broken-link">Akka.NET Documentation (Broken Link)</a></li>
+</ul>
+
 </body>
 </html>

--- a/src/LinkValidator.Tests/pages/page1.html
+++ b/src/LinkValidator.Tests/pages/page1.html
@@ -12,5 +12,11 @@
     <li><a href="/about/contact.html">Contact</a></li>
 </ul>
 
+<b>Other:</b>
+<ul>
+    <li><a href="https://phobos.petabridge.com/">Phobos</a></li>
+    <li><a href="https://getakka.net/">Akka.NET Documentation</a></li>
+</ul>
+
 </body>
 </html>

--- a/src/LinkValidator/Actors/IndexerActor.cs
+++ b/src/LinkValidator/Actors/IndexerActor.cs
@@ -55,6 +55,11 @@ public sealed class IndexerActor : UntypedActor, IWithTimers
     }
 
     public Dictionary<AbsoluteUri, (CrawlStatus status, CrawlRecord?)> IndexedDocuments { get; } = new();
+    
+    /// <summary>
+    /// Links that are external to the domain we're crawling.
+    /// </summary>
+    public Dictionary<AbsoluteUri, (CrawlStatus status, CrawlRecord?)> ExternalLinks { get; } = new();
 
     protected override void OnReceive(object message)
     {
@@ -76,7 +81,7 @@ public sealed class IndexerActor : UntypedActor, IWithTimers
                 }
 
                 // kick off scans of all the links on this page
-                foreach (var p in pageCrawled.Links)
+                foreach (var p in pageCrawled.InternalLinks)
                     if (!IndexedDocuments.TryGetValue(p, out var status) || status.status == CrawlStatus.NotVisited)
                     {
                         IndexedDocuments[p] = (CrawlStatus.Visiting,

--- a/src/LinkValidator/Actors/IndexerActor.cs
+++ b/src/LinkValidator/Actors/IndexerActor.cs
@@ -68,7 +68,7 @@ public sealed class IndexerActor : UntypedActor, IWithTimers
             case BeginIndexing:
                 _log.Info("Beginning indexing of [{0}]", _crawlConfiguration.BaseUrl);
                 IndexedDocuments[_crawlConfiguration.BaseUrl] = (CrawlStatus.Visiting, null);
-                _crawlers.Tell(new CrawlUrl(_crawlConfiguration.BaseUrl));
+                _crawlers.Tell(new CrawlUrl(_crawlConfiguration.BaseUrl, LinkType.Internal));
                 break;
             case PageCrawled pageCrawled:
             {
@@ -89,7 +89,7 @@ public sealed class IndexerActor : UntypedActor, IWithTimers
                             {
                                 LinksToPage = ImmutableList<AbsoluteUri>.Empty.Add(pageCrawled.Url)
                             });
-                        _crawlers.Tell(new CrawlUrl(p));
+                        _crawlers.Tell(new CrawlUrl(p, LinkType.Internal));
                     }
                     else
                     {
@@ -124,7 +124,7 @@ public sealed class IndexerActor : UntypedActor, IWithTimers
         }
     }
 
-    private bool IsCrawlComplete => IndexedDocuments.Values.All(x => x.status == CrawlStatus.Visited);
+    private bool IsCrawlComplete => IndexedDocuments.Values.All(x => x.status == CrawlStatus.Visited) && ExternalLinks.Values.All(x => x.status == CrawlStatus.Visited);
 
     protected override void PreStart()
     {

--- a/src/LinkValidator/Actors/UriTypes.cs
+++ b/src/LinkValidator/Actors/UriTypes.cs
@@ -23,6 +23,15 @@ public record struct AbsoluteUri
 }
 
 /// <summary>
+/// What type of link are we looking at?
+/// </summary>
+public enum LinkType
+{
+    Internal = 0,
+    External = 1
+}
+
+/// <summary>
 /// This is what we use in our final outputs for uniqueness and comparison
 /// </summary>
 public record struct RelativeUri

--- a/src/LinkValidator/Program.cs
+++ b/src/LinkValidator/Program.cs
@@ -44,7 +44,7 @@ class Program
             var system = ActorSystem.Create("CrawlerSystem", "akka.loglevel = INFO");
             var absoluteUri = new AbsoluteUri(new Uri(url));
             var results = await CrawlerHelper.CrawlWebsite(system, absoluteUri);
-            var markdown = GenerateMarkdown(absoluteUri, results);
+            var markdown = GenerateMarkdown(results);
 
             _ = system.Terminate();
 

--- a/src/LinkValidator/Util/CrawlerHelpers.cs
+++ b/src/LinkValidator/Util/CrawlerHelpers.cs
@@ -10,13 +10,24 @@ using LinkValidator.Actors;
 
 namespace LinkValidator.Util;
 
+/// <summary>
+/// Complete report on crawl processing.
+/// </summary>
+/// <param name="RootUri"></param>
+/// <param name="InternalLinks"></param>
+/// <param name="ExternalLinks"></param>
+public sealed record CrawlReport(
+    AbsoluteUri RootUri,
+    ImmutableSortedDictionary<string, CrawlRecord> InternalLinks,
+    ImmutableSortedDictionary<string, CrawlRecord> ExternalLinks);
+
 public static class CrawlerHelper
 {
-    public static async Task<ImmutableSortedDictionary<string, CrawlRecord>> CrawlWebsite(ActorSystem system,
+    public static async Task<CrawlReport> CrawlWebsite(ActorSystem system,
         AbsoluteUri url)
     {
         var crawlSettings = new CrawlConfiguration(url, 10, TimeSpan.FromSeconds(5));
-        var tcs = new TaskCompletionSource<ImmutableSortedDictionary<string, CrawlRecord>>();
+        var tcs = new TaskCompletionSource<CrawlReport>();
 
         var indexer = system.ActorOf(Props.Create(() => new IndexerActor(crawlSettings, tcs)), "indexer");
         indexer.Tell(IndexerActor.BeginIndexing.Instance);

--- a/src/LinkValidator/Util/MarkdownHelper.cs
+++ b/src/LinkValidator/Util/MarkdownHelper.cs
@@ -18,30 +18,36 @@ public static class MarkdownHelper
         var document = new MdDocument();
 
         // Add a header
-        document.Root.Add(new MdHeading(1, new MdTextSpan("Sitemap for "), new MdCodeSpan(GetCleanAbsoluteUrl(results.RootUri))));
-        var headerRow = new MdTableRow(new MdTextSpan("URL"), new MdTextSpan("StatusCode"), new MdTextSpan("Linked From"));
-        var rows = results.InternalLinks
+        document.Root.Add(new MdHeading(1, new MdTextSpan("Sitemap for "),
+            new MdCodeSpan(GetCleanAbsoluteUrl(results.RootUri))));
+
+        // Internal Pages
+        document.Root.Add(new MdHeading(2, new MdTextSpan("Internal Pages")));
+        var header1Row = new MdTableRow(new MdTextSpan("URL"), new MdTextSpan("StatusCode"),
+            new MdTextSpan("Linked From"));
+        var internalRows = results.InternalLinks
             .Select(kvp => new MdTableRow(
-                new MdCodeSpan(kvp.Key), 
+                new MdCodeSpan(kvp.Key),
                 new MdTextSpan(kvp.Value.StatusCode.ToString()),
                 FormatLinksToPageAsMarkdown(kvp.Value.LinksToPage, results.RootUri)));
 
-        // Add a table
-        document.Root.Add(new MdTable(headerRow, rows));
+        document.Root.Add(new MdTable(header1Row, internalRows));
 
         // Add broken links summary organized by source page
-        var brokenLinks = results.InternalLinks.Where(kvp => kvp.Value.StatusCode >= HttpStatusCode.BadRequest).ToList();
-        if (brokenLinks.Any())
+        var brokenLinks = results.InternalLinks.Where(kvp => kvp.Value.StatusCode >= HttpStatusCode.BadRequest)
+            .Concat(results.ExternalLinks.Where(c => c.Value.StatusCode >= HttpStatusCode.BadRequest)).ToList();
+        if (brokenLinks.Count != 0)
         {
             document.Root.Add(new MdHeading(2, "🔴 Pages with Broken Links"));
-            
+
             // Group broken links by the pages that link to them
             var pagesBrokenLinks = brokenLinks
                 .SelectMany(broken => broken.Value.LinksToPage
-                    .Select(linkingPage => new { 
+                    .Select(linkingPage => new
+                    {
                         SourcePage = GetCleanRelativePath(results.RootUri, linkingPage),
                         BrokenUrl = broken.Key,
-                        StatusCode = broken.Value.StatusCode 
+                        StatusCode = broken.Value.StatusCode
                     }))
                 .GroupBy(x => x.SourcePage)
                 .OrderBy(g => g.Key)
@@ -51,36 +57,38 @@ public static class MarkdownHelper
             {
                 foreach (var pageGroup in pagesBrokenLinks)
                 {
-                    document.Root.Add(new MdHeading(3, new MdCodeSpan(pageGroup.Key), new MdTextSpan(" has broken links:")));
-                    
+                    document.Root.Add(new MdHeading(3, new MdCodeSpan(pageGroup.Key),
+                        new MdTextSpan(" has broken links:")));
+
                     var brokenLinksForPage = pageGroup
                         .OrderBy(x => x.BrokenUrl)
                         .Select(x => new MdListItem(
-                            new MdCodeSpan(x.BrokenUrl), 
+                            new MdCodeSpan(x.BrokenUrl),
                             new MdTextSpan($" ({x.StatusCode})")))
                         .ToList();
-                    
+
                     document.Root.Add(new MdBulletList(brokenLinksForPage));
                 }
             }
-            
+
             // Handle orphaned broken links (no pages link to them)
             var orphanedLinks = brokenLinks
                 .Where(broken => broken.Value.LinksToPage.IsEmpty)
                 .ToList();
-                
+
             if (orphanedLinks.Any())
             {
                 document.Root.Add(new MdHeading(3, "🔗 Orphaned broken URLs"));
-                document.Root.Add(new MdParagraph(new MdEmphasisSpan("These URLs are broken but no pages link to them:")));
-                
+                document.Root.Add(
+                    new MdParagraph(new MdEmphasisSpan("These URLs are broken but no pages link to them:")));
+
                 var orphanedItems = orphanedLinks
                     .OrderBy(x => x.Key)
                     .Select(x => new MdListItem(
-                        new MdCodeSpan(x.Key), 
+                        new MdCodeSpan(x.Key),
                         new MdTextSpan($" ({x.Value.StatusCode})")))
                     .ToList();
-                    
+
                 document.Root.Add(new MdBulletList(orphanedItems));
             }
         }
@@ -89,7 +97,7 @@ public static class MarkdownHelper
         {
             TableStyle = MdTableStyle.GFM
         });
-        
+
         // Post-process to remove unwanted escaping of forward slashes
         return markdown.Replace("\\/", "/");
     }
@@ -107,7 +115,7 @@ public static class MarkdownHelper
 
         // Create a composite span with code spans for URLs and text spans for separators
         var spans = new List<MdSpan>();
-        
+
         var linksToShow = relativeLinks.Take(3).ToList();
         for (int i = 0; i < linksToShow.Count; i++)
         {
@@ -126,7 +134,7 @@ public static class MarkdownHelper
 
         return new MdCompositeSpan(spans);
     }
-    
+
     private static string FormatLinksToPage(ImmutableList<AbsoluteUri> linksToPage, AbsoluteUri baseUri)
     {
         if (linksToPage.IsEmpty)
@@ -156,17 +164,18 @@ public static class MarkdownHelper
         var host = uri.Value.Host;
         var port = uri.Value.Port;
         var path = uri.Value.AbsolutePath;
-        
+
         var url = $"{scheme}://{host}";
         if ((scheme == "http" && port != 80) || (scheme == "https" && port != 443))
         {
             url += $":{port}";
         }
+
         url += path;
-        
+
         return url;
     }
-    
+
     private static string GetCleanRelativePath(AbsoluteUri baseUri, AbsoluteUri targetUri)
     {
         // Just use the AbsolutePath to avoid any Uri escaping

--- a/src/LinkValidator/Util/ParseHelpers.cs
+++ b/src/LinkValidator/Util/ParseHelpers.cs
@@ -12,17 +12,17 @@ namespace LinkValidator.Util;
 
 public static class ParseHelpers
 {
-    public static IReadOnlyList<AbsoluteUri> ParseLinks(string html, AbsoluteUri baseUrl)
+    public static IReadOnlyList<(AbsoluteUri uri, LinkType type)> ParseLinks(string html, AbsoluteUri baseUrl)
     {
         var doc = new HtmlDocument();
         doc.LoadHtml(html);
 
-        IReadOnlyList<AbsoluteUri> links = doc.DocumentNode
+        IReadOnlyList<(AbsoluteUri uri, LinkType type)> links = doc.DocumentNode
             .SelectNodes("//a[@href]")?
             .Select(node => node.GetAttributeValue("href", ""))
             .Where(href => !string.IsNullOrEmpty(href) && CanMakeAbsoluteHttpUri(baseUrl, href))
             .Select(x => ToAbsoluteUri(baseUrl, x))
-            .Where(x => AbsoluteUriIsInDomain(baseUrl, x))
+            .Select(x => (x, AbsoluteUriIsInDomain(baseUrl, x) ? LinkType.Internal : LinkType.External))
             .Distinct() // filter duplicates - we're counting urls, not individual links
             .ToArray() ?? [];
         return links;


### PR DESCRIPTION
If we have broken external links, they shouldn't appear in the sitemap (which we don't even emit, currently) but they should definitely appear in the broken links report