### PR TITLE
Release 0.1.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,39 @@
-#### 0.1.0 Januard 3rd 2025 ####
+#### 0.1.0 September 4th 2025 ####
 
-Initial release
+**Initial Release**
+
+LinkValidator is a fast, reliable CLI tool for crawling websites and validating both internal and external links. Built with Akka.NET for high-performance concurrent crawling.
+
+**Features:**
+- **Fast Concurrent Crawling** - Leverages Akka.NET actors for efficient parallel processing of websites
+- **Smart External Link Handling** - Implements intelligent rate limiting with configurable retry policies for HTTP 429 responses
+- **Comprehensive Reporting** - Generates detailed markdown reports of all discovered links and their status
+- **Broken Link Tracking** - Tracks broken external links and provides detailed reporting on link status
+- **Advanced Error Handling** - Properly handles HTTP status codes 400+ as errors while allowing redirects and other success responses
+- **Link Graph Analysis** - Tracks relationships between pages to identify where broken links originate ([#32](https://github.com/Aaronontheweb/link-validator/pull/32))
+- **CI/CD Ready** - Perfect for automated testing in build pipelines with strict mode and exit codes
+- **Cross-Platform** - Single-file binaries for Windows, Linux, and macOS (Intel + Apple Silicon)
+- **Flexible Configuration** - CLI flags and environment variables for easy customization
+
+**Major Components:**
+- **HTTP 429 Rate Limit Handling** - Automatically detects and respects `Retry-After` headers, with configurable fallback delays and jitter to prevent thundering herd issues ([#63](https://github.com/Aaronontheweb/link-validator/pull/63))
+- **External Link Validation** - Comprehensive tracking and reporting of broken external URLs separate from internal site structure ([#62](https://github.com/Aaronontheweb/link-validator/pull/62))
+- **Smart HTTP Status Code Handling** - Only treats HTTP status codes 400 and above as errors, properly handling redirects and other success responses ([#61](https://github.com/Aaronontheweb/link-validator/pull/61))
+- **Release Infrastructure** - Complete release automation with configuration options and build system integration ([#64](https://github.com/Aaronontheweb/link-validator/pull/64))
+
+**Installation:**
+- Install scripts available for Windows PowerShell and Linux/macOS Bash
+- Pre-built single-file binaries for all major platforms  
+- Build from source with .NET 9 SDK
+
+**Command Line Options:**
+- `--url <URL>` - The website URL to crawl (required)
+- `--output <PATH>` - Save sitemap report to file
+- `--diff <PATH>` - Compare against previous sitemap file
+- `--strict` - Return error code if broken links found
+- `--max-external-retries <N>` - Max retries for external 429 responses (default: 3)
+- `--retry-delay-seconds <N>` - Default retry delay when no Retry-After header present (default: 10)
+
+**Environment Variable Support:**
+- `LINK_VALIDATOR_MAX_EXTERNAL_RETRIES` - Configure max retry attempts
+- `LINK_VALIDATOR_RETRY_DELAY_SECONDS` - Configure retry delay timing

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,21 +1,57 @@
 <Project>
-    <PropertyGroup>
-        <Copyright>Copyright © 2019-$([System.DateTime]::Now.Year) Aaron Stannard</Copyright>
-        <Authors>Aaron Stannard</Authors>
-        <VersionPrefix>0.1.0</VersionPrefix>
-        <PackageReleaseNotes>Initial release</PackageReleaseNotes>
-        <PackageIconUrl>
-        </PackageIconUrl>
-        <PackageProjectUrl>
+  <PropertyGroup>
+    <Copyright>Copyright © 2019-$([System.DateTime]::Now.Year) Aaron Stannard</Copyright>
+    <Authors>Aaron Stannard</Authors>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <PackageReleaseNotes>**Initial Release**
+
+LinkValidator is a fast, reliable CLI tool for crawling websites and validating both internal and external links. Built with Akka.NET for high-performance concurrent crawling.
+
+**Features:**
+- **Fast Concurrent Crawling** - Leverages Akka.NET actors for efficient parallel processing of websites
+- **Smart External Link Handling** - Implements intelligent rate limiting with configurable retry policies for HTTP 429 responses
+- **Comprehensive Reporting** - Generates detailed markdown reports of all discovered links and their status
+- **Broken Link Tracking** - Tracks broken external links and provides detailed reporting on link status
+- **Advanced Error Handling** - Properly handles HTTP status codes 400+ as errors while allowing redirects and other success responses
+- **Link Graph Analysis** - Tracks relationships between pages to identify where broken links originate ([#32](https://github.com/Aaronontheweb/link-validator/pull/32))
+- **CI/CD Ready** - Perfect for automated testing in build pipelines with strict mode and exit codes
+- **Cross-Platform** - Single-file binaries for Windows, Linux, and macOS (Intel + Apple Silicon)
+- **Flexible Configuration** - CLI flags and environment variables for easy customization
+
+**Major Components:**
+- **HTTP 429 Rate Limit Handling** - Automatically detects and respects `Retry-After` headers, with configurable fallback delays and jitter to prevent thundering herd issues ([#63](https://github.com/Aaronontheweb/link-validator/pull/63))
+- **External Link Validation** - Comprehensive tracking and reporting of broken external URLs separate from internal site structure ([#62](https://github.com/Aaronontheweb/link-validator/pull/62))
+- **Smart HTTP Status Code Handling** - Only treats HTTP status codes 400 and above as errors, properly handling redirects and other success responses ([#61](https://github.com/Aaronontheweb/link-validator/pull/61))
+- **Release Infrastructure** - Complete release automation with configuration options and build system integration ([#64](https://github.com/Aaronontheweb/link-validator/pull/64))
+
+**Installation:**
+- Install scripts available for Windows PowerShell and Linux/macOS Bash
+- Pre-built single-file binaries for all major platforms  
+- Build from source with .NET 9 SDK
+
+**Command Line Options:**
+- `--url &lt;URL&gt;` - The website URL to crawl (required)
+- `--output &lt;PATH&gt;` - Save sitemap report to file
+- `--diff &lt;PATH&gt;` - Compare against previous sitemap file
+- `--strict` - Return error code if broken links found
+- `--max-external-retries &lt;N&gt;` - Max retries for external 429 responses (default: 3)
+- `--retry-delay-seconds &lt;N&gt;` - Default retry delay when no Retry-After header present (default: 10)
+
+**Environment Variable Support:**
+- `LINK_VALIDATOR_MAX_EXTERNAL_RETRIES` - Configure max retry attempts
+- `LINK_VALIDATOR_RETRY_DELAY_SECONDS` - Configure retry delay timing</PackageReleaseNotes>
+    <PackageIconUrl>
+    </PackageIconUrl>
+    <PackageProjectUrl>
             https://github.com/Aaronontheweb/link-validator
         </PackageProjectUrl>
-        <PackageLicenseUrl>
-        </PackageLicenseUrl>
-        <NoWarn>$(NoWarn);CS1591</NoWarn>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    </PropertyGroup>
-    <PropertyGroup Label="SharedBuildProperties">
-        <TargetFramework>net9.0</TargetFramework>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+    <PackageLicenseUrl>
+    </PackageLicenseUrl>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Label="SharedBuildProperties">
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Release Preparation for v0.1.0

This PR prepares the initial release of LinkValidator with comprehensive documentation and updated package metadata.

### Changes
- **Release Notes**: Added detailed release notes documenting all features and functionality
- **Package Metadata**: Updated `Directory.Build.props` with complete release notes for NuGet packaging
- **Version**: Confirmed version 0.1.0 across all project files

### Release Features
- Fast concurrent crawling with Akka.NET actors
- Smart HTTP 429 rate limit handling with retry policies
- Comprehensive broken link tracking and reporting  
- Cross-platform single-file binaries
- CI/CD integration with strict mode
- Flexible configuration via CLI and environment variables

### Next Steps
After this PR is merged:
1. Create git tag `0.1.0` 
2. GitHub Actions will automatically create the release
3. Binaries will be published to GitHub Releases

Ready for review and merge to complete the 0.1.0 release process.