### PR TITLE
Fix PowerShell script PATH variable escaping

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -163,7 +163,7 @@ try {
                                elseif (Test-Path ~/.bashrc) { "~/.bashrc" } 
                                else { "~/.profile" }
                 
-                $PathLine = "export PATH=`"$InstallPath:`${PATH}`""
+                $PathLine = "export PATH=`"$InstallPath:\`$PATH`""
                 
                 if (-not (Get-Content $ShellProfile -ErrorAction SilentlyContinue | Select-String -Pattern [regex]::Escape($InstallPath))) {
                     Add-Content -Path $ShellProfile -Value $PathLine


### PR DESCRIPTION
- Escape $PATH variable properly to generate literal $ in bash export command
- Prevents PowerShell from trying to interpret $PATH as PowerShell variable