### PR TITLE
Fix install scripts and add .NET runtime requirement documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,30 @@ link-validator --url https://example.com --output new-sitemap.md --diff old-site
 
 ## 📦 Installation
 
+### Prerequisites
+
+**Required:** [.NET 9 Runtime](https://dotnet.microsoft.com/download/dotnet/9.0) must be installed on your system to run LinkValidator.
+
+- **Windows:** Download the [.NET 9 Runtime](https://dotnet.microsoft.com/download/dotnet/9.0/runtime)
+- **Linux/macOS:** Install via package manager or download from [Microsoft](https://dotnet.microsoft.com/download/dotnet/9.0)
+
 ### Option 1: Install Script (Recommended)
 
 **Windows (PowerShell):**
 ```powershell
-# Install to default location and add to PATH
 irm https://raw.githubusercontent.com/Aaronontheweb/link-validator/dev/install.ps1 | iex
+```
 
+**Linux/macOS (Bash):**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Aaronontheweb/link-validator/dev/install.sh | bash
+```
+
+<details>
+<summary>Advanced installation options</summary>
+
+**Windows custom options:**
+```powershell
 # Install to custom location  
 irm https://raw.githubusercontent.com/Aaronontheweb/link-validator/dev/install.ps1 | iex -ArgumentList "-InstallPath", "C:\tools\linkvalidator"
 
@@ -49,17 +66,15 @@ irm https://raw.githubusercontent.com/Aaronontheweb/link-validator/dev/install.p
 irm https://raw.githubusercontent.com/Aaronontheweb/link-validator/dev/install.ps1 | iex -ArgumentList "-SkipPath"
 ```
 
-**Linux/macOS (Bash):**
+**Linux/macOS custom options:**
 ```bash
-# Install to default location and add to PATH
-curl -fsSL https://raw.githubusercontent.com/Aaronontheweb/link-validator/dev/install.sh | bash
-
 # Install to custom location
 curl -fsSL https://raw.githubusercontent.com/Aaronontheweb/link-validator/dev/install.sh | bash -s -- --dir ~/.local/bin
 
 # Install without adding to PATH
 curl -fsSL https://raw.githubusercontent.com/Aaronontheweb/link-validator/dev/install.sh | bash -s -- --skip-path
 ```
+</details>
 
 ### Option 2: Download Binary
 
@@ -71,6 +86,8 @@ Download the appropriate binary from the [latest release](https://github.com/Aar
 - **macOS ARM64:** `link-validator-macos-arm64.tar.gz`
 
 Extract and place the binary in your PATH.
+
+**Note:** These binaries require the .NET 9 Runtime to be installed (see Prerequisites above).
 
 ### Option 3: Build from Source
 

--- a/install.ps1
+++ b/install.ps1
@@ -74,6 +74,16 @@ Write-Host "LinkValidator Installer" -ForegroundColor Green
 Write-Host "Platform: $Platform-$Architecture" -ForegroundColor Cyan
 Write-Host "Install Path: $InstallPath" -ForegroundColor Cyan
 
+# Check for .NET runtime
+try {
+    $null = & dotnet --version 2>$null
+} catch {
+    Write-Host "`nWARNING: .NET runtime not detected!" -ForegroundColor Yellow
+    Write-Host "LinkValidator requires .NET 9 Runtime to run." -ForegroundColor Yellow
+    Write-Host "Download from: https://dotnet.microsoft.com/download/dotnet/9.0" -ForegroundColor Yellow
+    Write-Host "Continuing with installation...`n" -ForegroundColor Cyan
+}
+
 # Get latest release info or specific version
 if ($Version) {
     $ReleaseUrl = "$GITHUB_API_URL/releases/tags/$Version"

--- a/install.ps1
+++ b/install.ps1
@@ -163,9 +163,9 @@ try {
                                elseif (Test-Path ~/.bashrc) { "~/.bashrc" } 
                                else { "~/.profile" }
                 
-                $PathLine = "export PATH=`"$InstallPath:\`$PATH`""
+                $PathLine = "export PATH=`"${InstallPath}:\`$PATH`""
                 
-                if (-not (Get-Content $ShellProfile -ErrorAction SilentlyContinue | Select-String -Pattern [regex]::Escape($InstallPath))) {
+                if (-not (Test-Path $ShellProfile) -or -not (Get-Content $ShellProfile -ErrorAction SilentlyContinue | Select-String -Pattern ([regex]::Escape($InstallPath)))) {
                     Add-Content -Path $ShellProfile -Value $PathLine
                     Write-Host "✓ Added to $ShellProfile. Run 'source $ShellProfile' or restart your terminal." -ForegroundColor Green
                 } else {

--- a/install.sh
+++ b/install.sh
@@ -96,10 +96,10 @@ fetch_release_info() {
     
     if [[ "$version" == "latest" ]]; then
         url="${GITHUB_API_URL}/releases/latest"
-        log_info "Fetching latest release..."
+        log_info "Fetching latest release..." >&2
     else
         url="${GITHUB_API_URL}/releases/tags/${version}"
-        log_info "Fetching release: $version"
+        log_info "Fetching release: $version" >&2
     fi
     
     if ! curl -fsSL -H "User-Agent: LinkValidator-Installer" "$url"; then
@@ -127,7 +127,7 @@ download_and_install() {
     # Find appropriate asset
     local asset_name="link-validator-${platform}.tar.gz"
     local download_url
-    download_url=$(echo "$release_json" | grep -A 3 "\"name\": \"$asset_name\"" | grep '"browser_download_url"' | sed 's/.*"browser_download_url": *"\([^"]*\)".*/\1/')
+    download_url=$(echo "$release_json" | grep -o '"browser_download_url":"[^"]*"' | grep "$asset_name" | sed 's/.*"browser_download_url":"\([^"]*\)".*/\1/' | head -1)
     
     if [[ -z "$download_url" ]]; then
         log_error "Could not find asset for platform: $platform"

--- a/install.sh
+++ b/install.sh
@@ -264,6 +264,15 @@ main() {
     log_info "Platform: $platform"
     log_info "Install directory: $install_dir"
     
+    # Check for .NET runtime
+    if ! command -v dotnet >/dev/null 2>&1; then
+        log_warning "WARNING: .NET runtime not detected!"
+        log_warning "LinkValidator requires .NET 9 Runtime to run."
+        log_warning "Download from: https://dotnet.microsoft.com/download/dotnet/9.0"
+        log_info "Continuing with installation..."
+        echo ""
+    fi
+    
     # Check dependencies
     for cmd in curl tar grep sed; do
         if ! command -v "$cmd" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fixes bash install script that was completely broken due to Windows line endings and JSON parsing issues
- Fixes PowerShell script PATH variable syntax error on Unix systems  
- Adds clear documentation about .NET 9 Runtime requirement

## Changes

### Bug Fixes
- Convert bash script from CRLF to LF line endings to fix execution on Unix systems
- Fix JSON parsing in bash script to handle single-line GitHub API responses
- Fix PowerShell PATH export syntax using `${InstallPath}` to properly escape colons
- Add file existence check before reading shell profile in PowerShell script

### Documentation Improvements
- Add Prerequisites section to README explaining .NET 9 Runtime requirement
- Add runtime detection to both install scripts with user warnings
- Simplify installation instructions with one-liner commands
- Move advanced install options to collapsible details section for cleaner docs

## Test Plan
- [x] Tested bash install script on Linux - successfully installs and adds to PATH
- [x] Tested PowerShell install script on Linux with pwsh - successfully installs
- [x] Verified installed binaries execute correctly with .NET runtime
- [x] Confirmed runtime detection warnings display when .NET is not installed