### PR TITLE
Add HTML comment-based link ignoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,37 @@ link-validator --url <URL> [OPTIONS]
 | `--help` | Show help information | - |
 | `--version` | Show version information | - |
 
+### Ignoring Links in HTML
+
+LinkValidator supports HTML comments to exclude specific links from validation. This is useful for development URLs, local services, or intentionally broken example links.
+
+#### Ignore Single Link
+
+Use `<!-- link-validator-ignore -->` to ignore just the next link:
+
+```html
+<!-- link-validator-ignore -->
+<a href="http://localhost:3000">This link will be ignored</a>
+<a href="http://localhost:9090">This link will be validated</a>
+```
+
+#### Ignore Block of Links
+
+Use `<!-- begin link-validator-ignore -->` and `<!-- end link-validator-ignore -->` to ignore all links within a section:
+
+```html
+<!-- begin link-validator-ignore -->
+<div>
+  <p>These local development links won't be validated:</p>
+  <a href="http://localhost:3000">Grafana Dashboard</a>
+  <a href="http://localhost:16686">Jaeger UI</a>
+  <a href="http://localhost:9090">Prometheus</a>
+</div>
+<!-- end link-validator-ignore -->
+```
+
+**Note:** Comments are case-insensitive, so `<!-- LINK-VALIDATOR-IGNORE -->`, `<!-- Link-Validator-Ignore -->`, etc. will all work.
+
 ### Environment Variables
 
 Override default values using environment variables:

--- a/src/LinkValidator.Tests/CommentBasedIgnoreSpecs.cs
+++ b/src/LinkValidator.Tests/CommentBasedIgnoreSpecs.cs
@@ -1,0 +1,161 @@
+// -----------------------------------------------------------------------
+// <copyright file="CommentBasedIgnoreSpecs.cs">
+//      Copyright (C) 2025 - 2025 Aaron Stannard <https://aaronstannard.com/>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using FluentAssertions;
+using LinkValidator.Actors;
+using LinkValidator.Util;
+using Xunit;
+
+namespace LinkValidator.Tests;
+
+public class CommentBasedIgnoreSpecs
+{
+    private readonly AbsoluteUri _baseUrl = new(new Uri("https://example.com/"));
+
+    [Fact]
+    public void Should_ignore_next_link_with_comment()
+    {
+        var html = @"
+            <html>
+                <body>
+                    <a href=""https://www.google.com"">Normal Link</a>
+                    <!-- link-validator-ignore-next -->
+                    <a href=""http://localhost:3000"">Ignored Link</a>
+                    <a href=""https://www.github.com"">Another Normal Link</a>
+                </body>
+            </html>";
+
+        var links = ParseHelpers.ParseLinks(html, _baseUrl);
+
+        links.Should().HaveCount(2);
+        links.Should().Contain(x => x.uri.Value.Host == "www.google.com");
+        links.Should().Contain(x => x.uri.Value.Host == "www.github.com");
+        links.Should().NotContain(x => x.uri.Value.Host == "localhost");
+    }
+
+    [Fact]
+    public void Should_ignore_all_links_within_comment_block()
+    {
+        var html = @"
+            <html>
+                <body>
+                    <a href=""https://www.google.com"">Normal Link</a>
+                    <!-- link-validator-ignore -->
+                    <div>
+                        <a href=""http://localhost:3000"">Ignored Link 1</a>
+                        <p>Some text with <a href=""http://localhost:9090"">Ignored Link 2</a></p>
+                        <ul>
+                            <li><a href=""http://localhost:16686"">Ignored Link 3</a></li>
+                        </ul>
+                    </div>
+                    <!-- /link-validator-ignore -->
+                    <a href=""https://www.github.com"">Another Normal Link</a>
+                </body>
+            </html>";
+
+        var links = ParseHelpers.ParseLinks(html, _baseUrl);
+
+        links.Should().HaveCount(2);
+        links.Should().Contain(x => x.uri.Value.Host == "www.google.com");
+        links.Should().Contain(x => x.uri.Value.Host == "www.github.com");
+        links.Should().NotContain(x => x.uri.Value.Host == "localhost");
+    }
+
+    [Fact]
+    public void Should_handle_nested_ignore_blocks()
+    {
+        var html = @"
+            <html>
+                <body>
+                    <!-- link-validator-ignore -->
+                    <a href=""http://localhost:3000"">Ignored Link 1</a>
+                    <div>
+                        <a href=""http://localhost:9090"">Ignored Link 2</a>
+                    </div>
+                    <!-- /link-validator-ignore -->
+                    <div>
+                        <a href=""https://www.google.com"">Normal Link</a>
+                    </div>
+                </body>
+            </html>";
+
+        var links = ParseHelpers.ParseLinks(html, _baseUrl);
+
+        links.Should().HaveCount(1);
+        links.Should().Contain(x => x.uri.Value.Host == "www.google.com");
+        links.Should().NotContain(x => x.uri.Value.Host == "localhost");
+    }
+
+    [Fact]
+    public void Should_only_ignore_next_immediate_link()
+    {
+        var html = @"
+            <html>
+                <body>
+                    <!-- link-validator-ignore-next -->
+                    <a href=""http://localhost:3000"">Ignored Link</a>
+                    <a href=""http://localhost:9090"">Not Ignored</a>
+                    <a href=""https://www.google.com"">Normal Link</a>
+                </body>
+            </html>";
+
+        var links = ParseHelpers.ParseLinks(html, _baseUrl);
+
+        links.Should().HaveCount(2);
+        links.Should().Contain(x => x.uri.Value.ToString().Contains("localhost:9090"));
+        links.Should().Contain(x => x.uri.Value.Host == "www.google.com");
+        links.Should().NotContain(x => x.uri.Value.ToString().Contains("localhost:3000"));
+    }
+
+    [Fact]
+    public void Should_handle_multiple_ignore_blocks()
+    {
+        var html = @"
+            <html>
+                <body>
+                    <a href=""https://www.google.com"">Normal Link 1</a>
+                    <!-- link-validator-ignore -->
+                    <a href=""http://localhost:3000"">Ignored Link 1</a>
+                    <!-- /link-validator-ignore -->
+                    <a href=""https://www.github.com"">Normal Link 2</a>
+                    <!-- link-validator-ignore -->
+                    <a href=""http://localhost:9090"">Ignored Link 2</a>
+                    <!-- /link-validator-ignore -->
+                    <a href=""https://www.stackoverflow.com"">Normal Link 3</a>
+                </body>
+            </html>";
+
+        var links = ParseHelpers.ParseLinks(html, _baseUrl);
+
+        links.Should().HaveCount(3);
+        links.Should().Contain(x => x.uri.Value.Host == "www.google.com");
+        links.Should().Contain(x => x.uri.Value.Host == "www.github.com");
+        links.Should().Contain(x => x.uri.Value.Host == "www.stackoverflow.com");
+        links.Should().NotContain(x => x.uri.Value.Host == "localhost");
+    }
+
+    [Fact]
+    public void Should_be_case_insensitive_for_comments()
+    {
+        var html = @"
+            <html>
+                <body>
+                    <!-- LINK-VALIDATOR-IGNORE-NEXT -->
+                    <a href=""http://localhost:3000"">Ignored Link 1</a>
+                    <!-- Link-Validator-Ignore -->
+                    <a href=""http://localhost:9090"">Ignored Link 2</a>
+                    <!-- /LINK-VALIDATOR-IGNORE -->
+                    <a href=""https://www.google.com"">Normal Link</a>
+                </body>
+            </html>";
+
+        var links = ParseHelpers.ParseLinks(html, _baseUrl);
+
+        links.Should().HaveCount(1);
+        links.Should().Contain(x => x.uri.Value.Host == "www.google.com");
+        links.Should().NotContain(x => x.uri.Value.Host == "localhost");
+    }
+}

--- a/src/LinkValidator.Tests/CommentBasedIgnoreSpecs.cs
+++ b/src/LinkValidator.Tests/CommentBasedIgnoreSpecs.cs
@@ -22,7 +22,7 @@ public class CommentBasedIgnoreSpecs
             <html>
                 <body>
                     <a href=""https://www.google.com"">Normal Link</a>
-                    <!-- link-validator-ignore-next -->
+                    <!-- link-validator-ignore -->
                     <a href=""http://localhost:3000"">Ignored Link</a>
                     <a href=""https://www.github.com"">Another Normal Link</a>
                 </body>
@@ -43,7 +43,7 @@ public class CommentBasedIgnoreSpecs
             <html>
                 <body>
                     <a href=""https://www.google.com"">Normal Link</a>
-                    <!-- link-validator-ignore -->
+                    <!-- begin link-validator-ignore -->
                     <div>
                         <a href=""http://localhost:3000"">Ignored Link 1</a>
                         <p>Some text with <a href=""http://localhost:9090"">Ignored Link 2</a></p>
@@ -51,7 +51,7 @@ public class CommentBasedIgnoreSpecs
                             <li><a href=""http://localhost:16686"">Ignored Link 3</a></li>
                         </ul>
                     </div>
-                    <!-- /link-validator-ignore -->
+                    <!-- end link-validator-ignore -->
                     <a href=""https://www.github.com"">Another Normal Link</a>
                 </body>
             </html>";
@@ -70,12 +70,12 @@ public class CommentBasedIgnoreSpecs
         var html = @"
             <html>
                 <body>
-                    <!-- link-validator-ignore -->
+                    <!-- begin link-validator-ignore -->
                     <a href=""http://localhost:3000"">Ignored Link 1</a>
                     <div>
                         <a href=""http://localhost:9090"">Ignored Link 2</a>
                     </div>
-                    <!-- /link-validator-ignore -->
+                    <!-- end link-validator-ignore -->
                     <div>
                         <a href=""https://www.google.com"">Normal Link</a>
                     </div>
@@ -95,7 +95,7 @@ public class CommentBasedIgnoreSpecs
         var html = @"
             <html>
                 <body>
-                    <!-- link-validator-ignore-next -->
+                    <!-- link-validator-ignore -->
                     <a href=""http://localhost:3000"">Ignored Link</a>
                     <a href=""http://localhost:9090"">Not Ignored</a>
                     <a href=""https://www.google.com"">Normal Link</a>
@@ -117,13 +117,13 @@ public class CommentBasedIgnoreSpecs
             <html>
                 <body>
                     <a href=""https://www.google.com"">Normal Link 1</a>
-                    <!-- link-validator-ignore -->
+                    <!-- begin link-validator-ignore -->
                     <a href=""http://localhost:3000"">Ignored Link 1</a>
-                    <!-- /link-validator-ignore -->
+                    <!-- end link-validator-ignore -->
                     <a href=""https://www.github.com"">Normal Link 2</a>
-                    <!-- link-validator-ignore -->
+                    <!-- begin link-validator-ignore -->
                     <a href=""http://localhost:9090"">Ignored Link 2</a>
-                    <!-- /link-validator-ignore -->
+                    <!-- end link-validator-ignore -->
                     <a href=""https://www.stackoverflow.com"">Normal Link 3</a>
                 </body>
             </html>";
@@ -143,11 +143,11 @@ public class CommentBasedIgnoreSpecs
         var html = @"
             <html>
                 <body>
-                    <!-- LINK-VALIDATOR-IGNORE-NEXT -->
+                    <!-- LINK-VALIDATOR-IGNORE -->
                     <a href=""http://localhost:3000"">Ignored Link 1</a>
-                    <!-- Link-Validator-Ignore -->
+                    <!-- Begin Link-Validator-Ignore -->
                     <a href=""http://localhost:9090"">Ignored Link 2</a>
-                    <!-- /LINK-VALIDATOR-IGNORE -->
+                    <!-- END LINK-VALIDATOR-IGNORE -->
                     <a href=""https://www.google.com"">Normal Link</a>
                 </body>
             </html>";

--- a/src/LinkValidator.Tests/End2EndSpecs.ShouldCrawlWebsiteCorrectly.verified.txt
+++ b/src/LinkValidator.Tests/End2EndSpecs.ShouldCrawlWebsiteCorrectly.verified.txt
@@ -16,13 +16,13 @@
 ### `/` has broken links:
 
 - `/page2.html` (NotFound)
-- `http://getakka.net/broken-link` (NotFound)
+- `https://getakka.net/broken-link` (NotFound)
 
 ### `/about/index.html` has broken links:
 
-- `http://getakka.net/broken-link` (NotFound)
+- `https://getakka.net/broken-link` (NotFound)
 
 ### `/index.html` has broken links:
 
 - `/page2.html` (NotFound)
-- `http://getakka.net/broken-link` (NotFound)
+- `https://getakka.net/broken-link` (NotFound)

--- a/src/LinkValidator/Util/ParseHelpers.cs
+++ b/src/LinkValidator/Util/ParseHelpers.cs
@@ -19,6 +19,7 @@ public static class ParseHelpers
 
         IReadOnlyList<(AbsoluteUri uri, LinkType type)> links = doc.DocumentNode
             .SelectNodes("//a[@href]")?
+            .Where(node => !IsLinkIgnored(node))
             .Select(node => node.GetAttributeValue("href", ""))
             .Where(href => !string.IsNullOrEmpty(href) && CanMakeAbsoluteHttpUri(baseUrl, href))
             .Select(x => ToAbsoluteUri(baseUrl, x))
@@ -26,5 +27,82 @@ public static class ParseHelpers
             .Distinct() // filter duplicates - we're counting urls, not individual links
             .ToArray() ?? [];
         return links;
+    }
+    
+    private static bool IsLinkIgnored(HtmlNode linkNode)
+    {
+        // Check if link is within an ignore block
+        if (IsWithinIgnoreBlock(linkNode))
+            return true;
+        
+        // Check if previous sibling is an ignore-next comment
+        var previousNode = linkNode.PreviousSibling;
+        while (previousNode != null)
+        {
+            if (previousNode.NodeType == HtmlNodeType.Comment)
+            {
+                var commentNode = (HtmlCommentNode)previousNode;
+                var commentText = commentNode.Comment.Trim();
+                // Remove comment delimiters and trim
+                commentText = commentText.Replace("<!--", "").Replace("-->", "").Trim();
+                if (commentText.Equals("link-validator-ignore-next", StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            else if (previousNode.NodeType == HtmlNodeType.Element)
+            {
+                // Stop looking if we hit another element
+                break;
+            }
+            previousNode = previousNode.PreviousSibling;
+        }
+        
+        return false;
+    }
+    
+    private static bool IsWithinIgnoreBlock(HtmlNode node)
+    {
+        // Start from the node and walk up the tree
+        var current = node;
+        
+        while (current != null)
+        {
+            // Check if there's an ignore block at this level
+            if (current.ParentNode != null)
+            {
+                var siblings = current.ParentNode.ChildNodes;
+                var inIgnoreBlock = false;
+                
+                foreach (var sibling in siblings)
+                {
+                    // Check for comment nodes
+                    if (sibling.NodeType == HtmlNodeType.Comment)
+                    {
+                        var commentNode = (HtmlCommentNode)sibling;
+                        var commentText = commentNode.Comment.Trim();
+                        // Remove comment delimiters and trim
+                        commentText = commentText.Replace("<!--", "").Replace("-->", "").Trim();
+                        
+                        if (commentText.Equals("link-validator-ignore", StringComparison.OrdinalIgnoreCase))
+                        {
+                            inIgnoreBlock = true;
+                        }
+                        else if (commentText.Equals("/link-validator-ignore", StringComparison.OrdinalIgnoreCase))
+                        {
+                            inIgnoreBlock = false;
+                        }
+                    }
+                    
+                    // If we've reached the current node and we're in an ignore block, return true
+                    if ((sibling == current || sibling.Descendants().Contains(node)) && inIgnoreBlock)
+                    {
+                        return true;
+                    }
+                }
+            }
+            
+            current = current.ParentNode;
+        }
+        
+        return false;
     }
 }

--- a/src/LinkValidator/Util/ParseHelpers.cs
+++ b/src/LinkValidator/Util/ParseHelpers.cs
@@ -45,7 +45,8 @@ public static class ParseHelpers
                 var commentText = commentNode.Comment.Trim();
                 // Remove comment delimiters and trim
                 commentText = commentText.Replace("<!--", "").Replace("-->", "").Trim();
-                if (commentText.Equals("link-validator-ignore-next", StringComparison.OrdinalIgnoreCase))
+                // Check for standalone ignore (not "begin")
+                if (commentText.Equals("link-validator-ignore", StringComparison.OrdinalIgnoreCase))
                     return true;
             }
             else if (previousNode.NodeType == HtmlNodeType.Element)
@@ -82,11 +83,11 @@ public static class ParseHelpers
                         // Remove comment delimiters and trim
                         commentText = commentText.Replace("<!--", "").Replace("-->", "").Trim();
                         
-                        if (commentText.Equals("link-validator-ignore", StringComparison.OrdinalIgnoreCase))
+                        if (commentText.Equals("begin link-validator-ignore", StringComparison.OrdinalIgnoreCase))
                         {
                             inIgnoreBlock = true;
                         }
-                        else if (commentText.Equals("/link-validator-ignore", StringComparison.OrdinalIgnoreCase))
+                        else if (commentText.Equals("end link-validator-ignore", StringComparison.OrdinalIgnoreCase))
                         {
                             inIgnoreBlock = false;
                         }

--- a/src/LinkValidator/Util/UriHelpers.cs
+++ b/src/LinkValidator/Util/UriHelpers.cs
@@ -91,13 +91,14 @@ public static class UriHelpers
             resolvedUri = new Uri(rawUri);
         }
 
-        // Ensure the scheme matches the base URI
-        if (resolvedUri.Scheme != baseUri.Value.Scheme)
+        // Only force scheme matching for internal URLs (same domain)
+        // External URLs should preserve their original scheme and port
+        if (resolvedUri.Host == baseUri.Value.Host && resolvedUri.Scheme != baseUri.Value.Scheme)
         {
             var builder = new UriBuilder(resolvedUri)
             {
                 Scheme = baseUri.Value.Scheme,
-                Port = -1, // Prevents adding the default port
+                Port = -1, // Prevents adding the default port for internal URLs
             };
             resolvedUri = builder.Uri;
         }


### PR DESCRIPTION
## Summary

This PR adds the ability to ignore specific links during validation using HTML comments. This is useful for development URLs, local services, or intentionally broken example links.

## Features

### Single Link Ignore
Use `<!-- link-validator-ignore -->` to ignore just the next link:
```html
<!-- link-validator-ignore -->
<a href="http://localhost:3000">This link will be ignored</a>
<a href="http://localhost:9090">This link will be validated</a>
```

### Block Ignore
Use `<!-- begin link-validator-ignore -->` and `<!-- end link-validator-ignore -->` to ignore all links within a section:
```html
<!-- begin link-validator-ignore -->
<div>
  <a href="http://localhost:3000">Grafana Dashboard</a>
  <a href="http://localhost:16686">Jaeger UI</a>
</div>
<!-- end link-validator-ignore -->
```

## Implementation Details

- Comments are case-insensitive
- Uses standard HTML comments (W3C compliant)
- No configuration required - works out of the box
- Links are still crawled but excluded from validation/reporting

## Additional Fixes

- Fixed a bug where external URLs were having their scheme and port incorrectly modified to match the base URL

## Testing

- Added comprehensive unit tests for both single link and block ignore scenarios
- All existing tests continue to pass