### PR TITLE
Prepare release 0.2.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+#### 0.2.0 February 17th 2026 ####
+
+**New Features:**
+- **Authenticated Crawling** - Added `--cookie-file` option for validating links behind login pages ([#145](https://github.com/Aaronontheweb/link-validator/pull/145))
+  - Accepts Netscape/Mozilla format cookie files (e.g. from `curl -c cookies.txt <url>`)
+  - Handles curl's `#HttpOnly_` prefix convention for HttpOnly cookies
+  - Cookies are shared across all crawler workers for consistent authenticated access
+  - Enables CI/CD link validation for apps that require authentication
+
+**Bug Fixes:**
+- **Fixed Flaky E2E Test** - Removed external network dependency from end-to-end test that caused non-deterministic failures when `getakka.net` responded slowly ([#145](https://github.com/Aaronontheweb/link-validator/pull/145))
+
 #### 0.1.2 September 5th 2025 ####
 
 **Bug Fixes:**

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,16 +2,16 @@
   <PropertyGroup>
     <Copyright>Copyright © 2019-$([System.DateTime]::Now.Year) Aaron Stannard</Copyright>
     <Authors>Aaron Stannard</Authors>
-    <VersionPrefix>0.1.2</VersionPrefix>
-    <PackageReleaseNotes>**Bug Fixes:**
-- **Improved External Link Validation** - Fixed false positives for legitimate external sites with slow response times ([#80](https://github.com/Aaronontheweb/link-validator/pull/80))
-  - External links that timeout now get retried using existing `--max-external-retries` and `--retry-delay-seconds` configuration
-  - Prevents false positives for legitimate sites that are simply responding slowly
-  - Maintains existing behavior for SSL errors and DNS failures (immediate failure, no retry)
-  - Retry attempts are logged and respect maximum retry limits with jitter
+    <VersionPrefix>0.2.0</VersionPrefix>
+    <PackageReleaseNotes>**New Features:**
+- **Authenticated Crawling** - Added `--cookie-file` option for validating links behind login pages ([#145](https://github.com/Aaronontheweb/link-validator/pull/145))
+  - Accepts Netscape/Mozilla format cookie files (e.g. from `curl -c cookies.txt`)
+  - Handles curl's `#HttpOnly_` prefix convention for HttpOnly cookies
+  - Cookies are shared across all crawler workers for consistent authenticated access
+  - Enables CI/CD link validation for apps that require authentication
 
-**Dependencies:**
-- Updated HtmlAgilityPack from 1.11.72 to 1.12.2 ([#77](https://github.com/Aaronontheweb/link-validator/pull/77))</PackageReleaseNotes>
+**Bug Fixes:**
+- **Fixed Flaky E2E Test** - Removed external network dependency from end-to-end test ([#145](https://github.com/Aaronontheweb/link-validator/pull/145))</PackageReleaseNotes>
     <PackageIconUrl>
     </PackageIconUrl>
     <PackageProjectUrl>


### PR DESCRIPTION
## Summary
- Bumps version from 0.1.2 to 0.2.0
- Updates RELEASE_NOTES.md with 0.2.0 changelog

## What's in 0.2.0
- **`--cookie-file` option** for authenticated crawling (#145)
- **Flaky E2E test fix** — removed external network dependency

After merge, tag with `v0.2.0` to trigger the release workflow.